### PR TITLE
feat: Support configure output type and shape

### DIFF
--- a/python/tf_op/module.py
+++ b/python/tf_op/module.py
@@ -14,14 +14,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import tensorflow as tf
+from tensorflow.python.framework import load_library
+
 
 class Module():
 
   def __init__(self, lib_path):
     self.lib_path = lib_path
 
-  def func(self, name, output_dtype="", output_shape="", device=""):
-    return Func(self.lib_path, name, output_dtype, output_shape, device)
+  def func(self, name, output_dtype=None, output_shape=None):
+    return Func(self.lib_path, name, output_dtype, output_shape)
 
   def __getitem__(self, func_name):
     return self.func(func_name)
@@ -29,14 +32,24 @@ class Module():
 
 class Func():
 
-  def __init__(self, lib_path, func_name, output_dtype, output_shape, device):
+  def __init__(self, lib_path, func_name, output_dtype, output_shape):
     self.lib_path = lib_path
     self.func_name = func_name
     self.output_dtype = output_dtype
-    self.output_shape = output_shape
-    self.device = device
 
-    from tensorflow.python.framework import load_library
+    # const(0) indicate invalid dynamic shape
+    self.dynamic_output_shape = tf.constant(0, tf.int64)
+    self.static_output_shape = None
+    self.has_static_output_shape = False  # extra flag is required
+
+    if self._is_static_shape(output_shape):
+      self.static_output_shape = output_shape
+      self.has_static_output_shape = True
+    elif output_shape is not None:
+      self.dynamic_output_shape = self._pack_shape_tensor(output_shape)
+    
+    # TODO: support non-xpu device 
+    #self.device = device
     # delay initialization to called first time, where num input arguments is known
     self.tvm_dso_op = None
     self.module = load_library.load_op_library('tvm_dso_op.so')
@@ -45,7 +58,45 @@ class Func():
     if self.tvm_dso_op is None:
       num_inputs = len(params)
       self.tvm_dso_op = getattr(self.module, "tvm_dso_op%s" % num_inputs)
-    return self.tvm_dso_op(*params, lib_path=self.lib_path, func_name=self.func_name, output_dtype=self.output_dtype, output_shape=self.output_shape, device=self.device)
+    
+    return self.tvm_dso_op(*params, 
+                           dynamic_output_shape=self.dynamic_output_shape,
+                           static_output_shape=self.static_output_shape,
+                           has_static_output_shape=self.has_static_output_shape, 
+                           lib_path=self.lib_path, 
+                           func_name=self.func_name, 
+                           output_dtype=self.output_dtype)
 
   def __call__(self, *params):
     return self.apply(*params)
+
+  def _is_static_shape(self, shape):
+    if shape is None or not isinstance(shape, list):
+      return False
+    for d in shape:
+      if not isinstance(d, int):
+        return False
+      if d < 0:
+        raise Exception("Negative dimension is illegal: %d" % d)
+    return True
+
+  def _pack_shape_tensor(self, shape):
+    if isinstance(shape, tf.Tensor):
+      return shape
+    elif isinstance(shape, list):
+      shape_dims = []
+      for d in shape:
+        if isinstance(d, int):
+          shape_dims.append(tf.constant(d, tf.int64))
+        elif isinstance(d, tf.Tensor) and len(d.shape) == 0:
+          if d.dtype == tf.int32:
+            d = tf.cast(d, tf.int64)
+          shape_dims.append(d)
+        else:
+          raise TypeError("Input shape dimension is neither scala tensor nor int")
+      return tf.stack(shape_dims) 
+    else:
+      raise TypeError("Input shape is neither tensor nor list")
+
+
+

--- a/src/tvm_dso_op_kernels.cc
+++ b/src/tvm_dso_op_kernels.cc
@@ -82,6 +82,14 @@ int GetDLPackDtype(const Tensor& tf_tensor, DLDataType* res) {
       res->code = kDLFloat;
       res->bits = 32;
       res->lanes = 1;
+    } else if (dtype == DT_INT64) {
+      res->code = kDLInt;
+      res->bits = 64;
+      res->lanes = 1;
+    } else if (dtype == DT_INT32) {
+      res->code = kDLInt;
+      res->bits = 32;
+      res->lanes = 1;
     } else {
       return -1;
     }

--- a/src/tvm_dso_ops.cc
+++ b/src/tvm_dso_ops.cc
@@ -22,61 +22,70 @@
 using namespace tensorflow;
 
 #define REGISTER_TFTVM_OP(n) REGISTER_OP("TvmDsoOp" #n) \
-    .Output("output: float") \
+    .Output("output: output_dtype") \
     .Attr("lib_path: string") \
     .Attr("func_name: string") \
-    .Attr("output_dtype: string") \
-    .Attr("output_shape: string") \
-    .Attr("device: string")
+    .Attr("output_dtype: {int32, int64, float} = DT_FLOAT") \
+    .Attr("static_output_shape: list(int) >= 0 = []") \
+    .Attr("has_static_output_shape: bool") \
 
 
-REGISTER_TFTVM_OP(1).Input("input: float");
+REGISTER_TFTVM_OP(1)
+    .Input("input: T").Attr("T: type") \
+    .Input("dynamic_output_shape: int64");
 
 REGISTER_TFTVM_OP(2)
-    .Input("input1: float")
-    .Input("input2: float");
+    .Input("input1: T1").Attr("T1: type")
+    .Input("input2: T2").Attr("T2: type")
+    .Input("dynamic_output_shape: int64");
 
 REGISTER_TFTVM_OP(3)
-    .Input("input1: float")
-    .Input("input2: float")
-    .Input("input3: float");
+    .Input("input1: T1").Attr("T1: type")
+    .Input("input2: T2").Attr("T2: type")
+    .Input("input3: T3").Attr("T3: type")
+    .Input("dynamic_output_shape: int64");
 
 REGISTER_TFTVM_OP(4)
-    .Input("input1: float")
-    .Input("input2: float")
-    .Input("input3: float")
-    .Input("input4: float");
+    .Input("input1: T1").Attr("T1: type")
+    .Input("input2: T2").Attr("T2: type")
+    .Input("input3: T3").Attr("T3: type")
+    .Input("input4: T4").Attr("T4: type")
+    .Input("dynamic_output_shape: int64");
 
 REGISTER_TFTVM_OP(5)
-    .Input("input1: float")
-    .Input("input2: float")
-    .Input("input3: float")
-    .Input("input4: float")
-    .Input("input5: float");
+    .Input("input1: T1").Attr("T1: type")
+    .Input("input2: T2").Attr("T2: type")
+    .Input("input3: T3").Attr("T3: type")
+    .Input("input4: T4").Attr("T4: type")
+    .Input("input5: T5").Attr("T5: type")
+    .Input("dynamic_output_shape: int64");
 
 REGISTER_TFTVM_OP(6)
-    .Input("input1: float")
-    .Input("input2: float")
-    .Input("input3: float")
-    .Input("input4: float")
-    .Input("input5: float")
-    .Input("input6: float");
+    .Input("input1: T1").Attr("T1: type")
+    .Input("input2: T2").Attr("T2: type")
+    .Input("input3: T3").Attr("T3: type")
+    .Input("input4: T4").Attr("T4: type")
+    .Input("input5: T5").Attr("T5: type")
+    .Input("input6: T6").Attr("T6: type")
+    .Input("dynamic_output_shape: int64");
 
 REGISTER_TFTVM_OP(7)
-    .Input("input1: float")
-    .Input("input2: float")
-    .Input("input3: float")
-    .Input("input4: float")
-    .Input("input5: float")
-    .Input("input6: float")
-    .Input("input7: float");
+    .Input("input1: T1").Attr("T1: type")
+    .Input("input2: T2").Attr("T2: type")
+    .Input("input3: T3").Attr("T3: type")
+    .Input("input4: T4").Attr("T4: type")
+    .Input("input5: T5").Attr("T5: type")
+    .Input("input6: T6").Attr("T6: type")
+    .Input("input7: T7").Attr("T7: type")
+    .Input("dynamic_output_shape: int64");
 
 REGISTER_TFTVM_OP(8)
-    .Input("input1: float")
-    .Input("input2: float")
-    .Input("input3: float")
-    .Input("input4: float")
-    .Input("input5: float")
-    .Input("input6: float")
-    .Input("input7: float")
-    .Input("input8: float");
+    .Input("input1: T1").Attr("T1: type")
+    .Input("input2: T2").Attr("T2: type")
+    .Input("input3: T3").Attr("T3: type")
+    .Input("input4: T4").Attr("T4: type")
+    .Input("input5: T5").Attr("T5: type")
+    .Input("input6: T6").Attr("T6: type")
+    .Input("input7: T7").Attr("T7: type")
+    .Input("input8: T8").Attr("T8: type")
+    .Input("dynamic_output_shape: int64");


### PR DESCRIPTION
- Propose two approach to specify output attributes

    - By op attr "static output shape"
      ```python
      # [1, 2, 3] passed as op attr 
      # keep fixed for all inputs 
      module.func("op_name", output_shape=[1,2,3])
      ```

    - By implicit input tensor act as dynamic shape dimensions  
       ```python
       # pass one-dimension tensor represent expected output shape
       # output shape maybe different for different input shape, eg, batch_size
       module.func("op_name", output_shape=tf.shape(x))
       ```

    - Seems not necessary to use both, may pick only one approach finally 

- Remove device attr since cpu/gpu device is already determined by tf op

- Fix an alignment computation bug